### PR TITLE
Fix typo in setSearchFilter docs and regenerate docs

### DIFF
--- a/docs/classes/autocomplete.controller.html
+++ b/docs/classes/autocomplete.controller.html
@@ -1045,7 +1045,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L46">controller.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L46">controller.ts:46</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1080,7 +1080,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L170">controller.ts:170</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L170">controller.ts:170</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1103,7 +1103,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L196">controller.ts:196</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L196">controller.ts:196</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1126,7 +1126,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L232">controller.ts:232</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L232">controller.ts:232</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1157,7 +1157,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L72">controller.ts:72</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L72">controller.ts:72</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1187,7 +1187,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L271">controller.ts:271</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L271">controller.ts:271</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1209,7 +1209,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L124">controller.ts:124</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L124">controller.ts:124</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1240,7 +1240,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L87">controller.ts:87</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L87">controller.ts:87</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1270,7 +1270,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L149">controller.ts:149</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L149">controller.ts:149</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1303,7 +1303,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L108">controller.ts:108</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L108">controller.ts:108</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1334,7 +1334,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L282">controller.ts:282</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L282">controller.ts:282</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1364,7 +1364,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L98">controller.ts:98</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L98">controller.ts:98</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1374,7 +1374,7 @@ img { max-width: 100%; }
 							</div>
 							<dl class="tsd-comment-tags">
 								<dt>example</dt>
-								<dd><p><code>controller.setSearchFilter({postcode_outward: &quot;SW1A&quot;})</code></p>
+								<dd><p><code>controller.setSearchFilter({postcode_outward: [&quot;SW1A&quot;]})</code></p>
 								</dd>
 							</dl>
 						</div>

--- a/docs/classes/autocomplete.interface.html
+++ b/docs/classes/autocomplete.interface.html
@@ -1082,7 +1082,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L35">interface.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L35">interface.ts:35</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1117,7 +1117,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L107">interface.ts:107</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L107">interface.ts:107</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1144,7 +1144,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L119">interface.ts:119</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L119">interface.ts:119</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1171,7 +1171,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L130">interface.ts:130</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L130">interface.ts:130</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1203,7 +1203,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L166">interface.ts:166</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L166">interface.ts:166</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1239,7 +1239,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L140">interface.ts:140</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L140">interface.ts:140</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1271,7 +1271,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L245">interface.ts:245</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L245">interface.ts:245</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1294,7 +1294,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L189">interface.ts:189</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L189">interface.ts:189</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1316,7 +1316,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L297">interface.ts:297</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L297">interface.ts:297</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1339,7 +1339,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L78">interface.ts:78</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L78">interface.ts:78</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1368,7 +1368,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L91">interface.ts:91</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L91">interface.ts:91</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1397,7 +1397,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L53">interface.ts:53</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L53">interface.ts:53</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1426,7 +1426,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L266">interface.ts:266</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L266">interface.ts:266</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="autocomplete.interface.html" class="tsd-signature-type">Interface</a></h4>
@@ -1443,7 +1443,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L253">interface.ts:253</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L253">interface.ts:253</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="autocomplete.interface.html" class="tsd-signature-type">Interface</a></h4>
@@ -1460,7 +1460,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L259">interface.ts:259</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L259">interface.ts:259</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1477,7 +1477,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L272">interface.ts:272</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L272">interface.ts:272</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="autocomplete.interface.html" class="tsd-signature-type">Interface</a></h4>
@@ -1494,7 +1494,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L215">interface.ts:215</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L215">interface.ts:215</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1516,7 +1516,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L278">interface.ts:278</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L278">interface.ts:278</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1539,7 +1539,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L321">interface.ts:321</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L321">interface.ts:321</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1562,7 +1562,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L336">interface.ts:336</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L336">interface.ts:336</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1579,7 +1579,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L200">interface.ts:200</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L200">interface.ts:200</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1607,7 +1607,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L238">interface.ts:238</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L238">interface.ts:238</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/index.html
+++ b/docs/index.html
@@ -976,10 +976,10 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">Autocomplete<span class="tsd-signature-symbol">:</span> </div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L2">utils.ts:2</a></li>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/interface.ts#L4">interface.ts:4</a></li>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L10">index.ts:10</a></li>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/controller.ts#L4">controller.ts:4</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L2">utils.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/interface.ts#L4">interface.ts:4</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L10">index.ts:10</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/controller.ts#L4">controller.ts:4</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/autocomplete.addressfields.html
+++ b/docs/interfaces/autocomplete.addressfields.html
@@ -1114,7 +1114,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">administrative_<wbr>county<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L278">index.ts:278</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L278">index.ts:278</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1130,7 +1130,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">building_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L158">index.ts:158</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L158">index.ts:158</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1146,7 +1146,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">building_<wbr>number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L152">index.ts:152</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L152">index.ts:152</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1162,7 +1162,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">country<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L266">index.ts:266</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L266">index.ts:266</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1178,7 +1178,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">county<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L290">index.ts:290</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L290">index.ts:290</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1194,7 +1194,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">delivery_<wbr>point_<wbr>suffix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L212">index.ts:212</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L212">index.ts:212</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1210,7 +1210,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">department_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L176">index.ts:176</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L176">index.ts:176</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1226,7 +1226,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">dependant_<wbr>locality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L128">index.ts:128</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L128">index.ts:128</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1242,7 +1242,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">dependant_<wbr>thoroughfare<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L146">index.ts:146</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L146">index.ts:146</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1258,7 +1258,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">district<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L296">index.ts:296</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L296">index.ts:296</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1274,7 +1274,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">double_<wbr>dependant_<wbr>locality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L134">index.ts:134</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L134">index.ts:134</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1290,7 +1290,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">eastings<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L254">index.ts:254</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L254">index.ts:254</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1306,7 +1306,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">latitude<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L248">index.ts:248</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L248">index.ts:248</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1322,7 +1322,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">line_<wbr>1<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L218">index.ts:218</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L218">index.ts:218</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1338,7 +1338,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">line_<wbr>2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L224">index.ts:224</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L224">index.ts:224</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1354,7 +1354,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">line_<wbr>3<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L230">index.ts:230</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L230">index.ts:230</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1370,7 +1370,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">longitude<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L242">index.ts:242</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L242">index.ts:242</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1386,7 +1386,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">northings<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L260">index.ts:260</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L260">index.ts:260</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1402,7 +1402,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">organisation_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L182">index.ts:182</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L182">index.ts:182</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1418,7 +1418,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">po_<wbr>box<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L170">index.ts:170</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L170">index.ts:170</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1434,7 +1434,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">post_<wbr>town<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L122">index.ts:122</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L122">index.ts:122</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1450,7 +1450,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">postal_<wbr>county<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L284">index.ts:284</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L284">index.ts:284</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1466,7 +1466,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">postcode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L104">index.ts:104</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L104">index.ts:104</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1482,7 +1482,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">postcode_<wbr>inward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L110">index.ts:110</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L110">index.ts:110</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1498,7 +1498,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">postcode_<wbr>outward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L116">index.ts:116</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L116">index.ts:116</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1514,7 +1514,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">postcode_<wbr>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L200">index.ts:200</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L200">index.ts:200</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1530,7 +1530,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">premise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L236">index.ts:236</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L236">index.ts:236</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1546,7 +1546,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">su_<wbr>organisation_<wbr>indicator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L206">index.ts:206</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L206">index.ts:206</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1562,7 +1562,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">sub_<wbr>building_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L164">index.ts:164</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L164">index.ts:164</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1578,7 +1578,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">thoroughfare<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L140">index.ts:140</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L140">index.ts:140</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1594,7 +1594,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">traditional_<wbr>county<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L272">index.ts:272</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L272">index.ts:272</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1610,7 +1610,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">udprn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L188">index.ts:188</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L188">index.ts:188</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1626,7 +1626,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">umprn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L194">index.ts:194</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L194">index.ts:194</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1642,7 +1642,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">ward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L302">index.ts:302</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L302">index.ts:302</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/autocomplete.autocompleteoptions.html
+++ b/docs/interfaces/autocomplete.autocompleteoptions.html
@@ -1016,7 +1016,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">_id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L89">index.ts:89</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L89">index.ts:89</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/autocomplete.callbackoptions.html
+++ b/docs/interfaces/autocomplete.callbackoptions.html
@@ -1017,7 +1017,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Address<wbr>Retrieved<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L339">index.ts:339</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L339">index.ts:339</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1056,7 +1056,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Address<wbr>Selected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L331">index.ts:331</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L331">index.ts:331</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1094,7 +1094,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Blur<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L359">index.ts:359</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L359">index.ts:359</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1125,7 +1125,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Close<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L365">index.ts:365</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L365">index.ts:365</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1156,7 +1156,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Failed<wbr>Check<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L317">index.ts:317</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L317">index.ts:317</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1188,7 +1188,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Focus<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L371">index.ts:371</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L371">index.ts:371</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1219,7 +1219,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L377">index.ts:377</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L377">index.ts:377</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1256,7 +1256,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Loaded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L310">index.ts:310</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L310">index.ts:310</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1287,7 +1287,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Open<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L353">index.ts:353</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L353">index.ts:353</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1318,7 +1318,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Search<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L347">index.ts:347</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L347">index.ts:347</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1357,7 +1357,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Suggestions<wbr>Retrieved<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L324">index.ts:324</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L324">index.ts:324</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/autocomplete.controlleroptions.html
+++ b/docs/interfaces/autocomplete.controlleroptions.html
@@ -1105,7 +1105,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">check<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L404">index.ts:404</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L404">index.ts:404</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1135,7 +1135,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfaceoptions.html">InterfaceOptions</a>.<a href="autocomplete.interfaceoptions.html#inputfield">inputField</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L84">index.ts:84</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L84">index.ts:84</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1163,7 +1163,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onaddressretrieved">onAddressRetrieved</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L339">index.ts:339</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L339">index.ts:339</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1203,7 +1203,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onaddressselected">onAddressSelected</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L331">index.ts:331</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L331">index.ts:331</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1243,7 +1243,7 @@ img { max-width: 100%; }
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onblur">onBlur</a></p>
 					<p>Overrides <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onblur">onBlur</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L59">index.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L59">index.ts:59</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1275,7 +1275,7 @@ img { max-width: 100%; }
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onclose">onClose</a></p>
 					<p>Overrides <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onclose">onClose</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L62">index.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L62">index.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1306,7 +1306,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onfailedcheck">onFailedCheck</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L317">index.ts:317</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L317">index.ts:317</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1340,7 +1340,7 @@ img { max-width: 100%; }
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onfocus">onFocus</a></p>
 					<p>Overrides <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onfocus">onFocus</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L65">index.ts:65</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L65">index.ts:65</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1372,7 +1372,7 @@ img { max-width: 100%; }
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#oninput">onInput</a></p>
 					<p>Overrides <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#oninput">onInput</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L68">index.ts:68</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L68">index.ts:68</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1409,7 +1409,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onloaded">onLoaded</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L310">index.ts:310</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L310">index.ts:310</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1442,7 +1442,7 @@ img { max-width: 100%; }
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onopen">onOpen</a></p>
 					<p>Overrides <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onopen">onOpen</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L56">index.ts:56</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L56">index.ts:56</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1473,7 +1473,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onsearcherror">onSearchError</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L347">index.ts:347</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L347">index.ts:347</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1513,7 +1513,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onselect">onSelect</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L71">index.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L71">index.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1550,7 +1550,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.callbackoptions.html">CallbackOptions</a>.<a href="autocomplete.callbackoptions.html#onsuggestionsretrieved">onSuggestionsRetrieved</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L324">index.ts:324</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L324">index.ts:324</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1588,7 +1588,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">output<wbr>Fields<span class="tsd-signature-symbol">:</span> <a href="autocomplete.addressfields.html" class="tsd-signature-type">AddressFields</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L390">index.ts:390</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L390">index.ts:390</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1608,7 +1608,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">remove<wbr>Organisation<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L397">index.ts:397</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L397">index.ts:397</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1648,7 +1648,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">titleize<wbr>Post<wbr>Town<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L409">index.ts:409</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L409">index.ts:409</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/autocomplete.interfacecallbacks.html
+++ b/docs/interfaces/autocomplete.interfacecallbacks.html
@@ -1005,7 +1005,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Blur<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L59">index.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L59">index.ts:59</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1035,7 +1035,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Close<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L62">index.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L62">index.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1065,7 +1065,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Focus<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L65">index.ts:65</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L65">index.ts:65</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1095,7 +1095,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L68">index.ts:68</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L68">index.ts:68</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1131,7 +1131,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Open<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L56">index.ts:56</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L56">index.ts:56</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1161,7 +1161,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">on<wbr>Select<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L71">index.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L71">index.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/autocomplete.interfaceoptions.html
+++ b/docs/interfaces/autocomplete.interfaceoptions.html
@@ -1014,7 +1014,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">input<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L84">index.ts:84</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L84">index.ts:84</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1031,7 +1031,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onblur">onBlur</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L59">index.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L59">index.ts:59</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1062,7 +1062,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onclose">onClose</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L62">index.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L62">index.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1093,7 +1093,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onfocus">onFocus</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L65">index.ts:65</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L65">index.ts:65</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1124,7 +1124,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#oninput">onInput</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L68">index.ts:68</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L68">index.ts:68</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1161,7 +1161,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onopen">onOpen</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L56">index.ts:56</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L56">index.ts:56</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1192,7 +1192,7 @@ img { max-width: 100%; }
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="autocomplete.interfacecallbacks.html">InterfaceCallbacks</a>.<a href="autocomplete.interfacecallbacks.html#onselect">onSelect</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L71">index.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L71">index.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/autocomplete.suggestion.html
+++ b/docs/interfaces/autocomplete.suggestion.html
@@ -993,7 +993,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">suggestion<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L36">index.ts:36</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L36">index.ts:36</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1013,7 +1013,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">udprn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L44">index.ts:44</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L44">index.ts:44</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1028,7 +1028,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">umprn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L46">index.ts:46</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L46">index.ts:46</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1043,7 +1043,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">urls<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/index.ts#L37">index.ts:37</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/index.ts#L37">index.ts:37</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">

--- a/docs/modules/autocomplete.utils.html
+++ b/docs/modules/autocomplete.utils.html
@@ -1004,7 +1004,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">boness<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/bo&#x27;ness/i</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L22">utils.ts:22</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L22">utils.ts:22</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1023,7 +1023,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">contains<wbr>Ampersand<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/\w+&amp;\w+/</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L29">utils.ts:29</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L29">utils.ts:29</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1042,7 +1042,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">exclusion<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/^(of|le|upon|on|the)$/</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L36">utils.ts:36</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L36">utils.ts:36</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1061,7 +1061,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">joiner<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/-/</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L15">utils.ts:15</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L15">utils.ts:15</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1080,7 +1080,7 @@ img { max-width: 100%; }
 				<div class="tsd-signature tsd-kind-icon">joiner<wbr>Word<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/^(in|de|under|upon|y|on|over|the|by)$/</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L43">utils.ts:43</a></li>
+						<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L43">utils.ts:43</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -1106,7 +1106,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L122">utils.ts:122</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L122">utils.ts:122</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1137,7 +1137,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L49">utils.ts:49</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L49">utils.ts:49</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1165,7 +1165,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L75">utils.ts:75</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L75">utils.ts:75</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1193,7 +1193,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L60">utils.ts:60</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L60">utils.ts:60</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1221,7 +1221,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L97">utils.ts:97</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L97">utils.ts:97</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1252,7 +1252,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L136">utils.ts:136</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L136">utils.ts:136</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1283,7 +1283,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L159">utils.ts:159</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L159">utils.ts:159</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1312,7 +1312,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L84">utils.ts:84</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L84">utils.ts:84</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -1340,7 +1340,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/d8a77cf/lib/utils.ts#L149">utils.ts:149</a></li>
+								<li>Defined in <a href="https://github.com/ideal-postcodes/ideal-postcodes-autocomplete/blob/e445aee/lib/utils.ts#L149">utils.ts:149</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -93,7 +93,7 @@ namespace Autocomplete {
 		 * outward postcode)
 		 * @param {IdealPostcodes.SearchFilters} options
 		 * @public
-		 * @example `controller.setSearchFilter({postcode_outward: "SW1A"})`
+		 * @example `controller.setSearchFilter({postcode_outward: ["SW1A"]})`
 		 */
 		setSearchFilter(options: IdealPostcodes.SearchFilters): void {
 			this.searchFilters = options;


### PR DESCRIPTION
`setSearchFilter` needs an array of postcode outward strings